### PR TITLE
Laravel 5.5 compatibility fix

### DIFF
--- a/src/Console/SecurityCommand.php
+++ b/src/Console/SecurityCommand.php
@@ -9,11 +9,15 @@ use SensioLabs\Security\SecurityChecker;
 class SecurityCommand extends Command
 {
     /**
+     * The name and signature of the console command.
+     *
      * @var string
      */
     protected $name = 'security-check:now';
 
     /**
+     * The console command description.
+     *
      * @var string
      */
     protected $description = 'Checks composer.lock for any vulnerabilities against the SensioLabs checker.';
@@ -36,9 +40,9 @@ class SecurityCommand extends Command
     }
 
     /**
-     * Fire the command
+     * Execute the console command.
      */
-    public function fire()
+    public function handle()
     {
         // get the path to composer.lock
         $composerLock = base_path('composer.lock');

--- a/src/Console/SecurityMailCommand.php
+++ b/src/Console/SecurityMailCommand.php
@@ -10,11 +10,14 @@ use SensioLabs\Security\SecurityChecker;
 class SecurityMailCommand extends Command
 {
     /**
+     * The name and signature of the console command.
+     *
      * @var string
      */
     protected $name = 'security-check:email';
 
     /**
+     * The console command description.
      * @var string
      */
     protected $description = 'Emails any vulnerabilities for packages you have in your composer.lock file.';
@@ -37,9 +40,9 @@ class SecurityMailCommand extends Command
     }
 
     /**
-     * Fire the command
+     * Execute the console command.
      */
-    public function fire()
+    public function handle()
     {
         // get the path to composer.lock
         $composerLock = base_path('composer.lock');


### PR DESCRIPTION
Renamed the fire() methods to handle() for the two console commands so that the package is compatible with Laravel 5.5 LTS.

The upgrade guides states, "Any fire methods present on your Artisan commands should be renamed to handle." - https://laravel.com/docs/5.5/upgrade#upgrade-5.5.0