### PR TITLE
Upgrade to support Laravel 5.5 - resolves #11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - 7.2

--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ _Note: On Laravel 5.5 and up, this package will use auto discovery, and the abov
 ### Configuration
 If you want the package to send reports by email, you'll need to specify a recipient.
 
+If you want the pacakge to send the report to a Slack channel, you will need to specify a Slack Webhook
+in your `.env` file.
+
+E.g.:
+
+```
+LCS_SLACK_WEBHOOK=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
+```
+
 #### Option 1
 Add it to your `.env` file.
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "require-dev": {
     "illuminate/config": "^5.0,>5.4,<5.6",
     "illuminate/view": "^5.0,>5.4,<5.6",
-    "phpunit/phpunit": "4.*",
+    "phpunit/phpunit": "~6.0",
     "scrutinizer/ocular": "~1.1",
     "squizlabs/php_codesniffer": "~2.3",
     "orchestra/testbench": "~3.4",

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
   "require": {
     "sensiolabs/security-checker": "^4.0.0",
     "php": ">=5.6.4",
+    "guzzlehttp/guzzle": "^6.3",
     "illuminate/support": "^5.0,>5.4,<5.6",
     "illuminate/console": "^5.0,>5.4,<5.6",
     "illuminate/mail": "^5.0,>5.4,<5.6",

--- a/config/laravel-security-checker.php
+++ b/config/laravel-security-checker.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-
     /*
     |--------------------------------------------------------------------------
     | Laravel Security Checker — Recipients
@@ -26,4 +25,15 @@ return [
      */
 
     'email_even_without_vulnerabilities' => env('LCS_EMAIL_WITHOUT_VULNERABILITIES', false),
+
+    /*
+     |--------------------------------------------------------------------------
+     | Laravel Security Checker — Slack Webhook URL
+     |--------------------------------------------------------------------------
+     |
+     | Which Slack Webhook URL should we post to when using Slack notifications?
+     |
+     */
+
+    'slack_webhook_url' => env('LCS_SLACK_WEBHOOK', null),
 ];

--- a/src/Console/SecurityCommand.php
+++ b/src/Console/SecurityCommand.php
@@ -36,9 +36,9 @@ class SecurityCommand extends Command
     }
 
     /**
-     * Fire the command
+     * Execute the command
      */
-    public function fire()
+    public function handle()
     {
         // get the path to composer.lock
         $composerLock = base_path('composer.lock');

--- a/src/Console/SecurityMailCommand.php
+++ b/src/Console/SecurityMailCommand.php
@@ -55,7 +55,7 @@ class SecurityMailCommand extends Command
         }
 
         // get the recipients and filter out any configuration mistakes
-        $recipients = collect(config('laravel-security-checker.recipients', []))->filter(function ($recipient) {
+        $recipients = collect(config('laravel-security-checker.recipients', [ ]))->filter(function($recipient) {
             return !is_null($recipient) && !empty($recipient);
         });
 

--- a/src/Console/SecurityMailCommand.php
+++ b/src/Console/SecurityMailCommand.php
@@ -37,9 +37,9 @@ class SecurityMailCommand extends Command
     }
 
     /**
-     * Fire the command
+     * Execute the command
      */
-    public function fire()
+    public function handle()
     {
         // get the path to composer.lock
         $composerLock = base_path('composer.lock');
@@ -55,7 +55,7 @@ class SecurityMailCommand extends Command
         }
 
         // get the recipients and filter out any configuration mistakes
-        $recipients = collect(config('laravel-security-checker.recipients', [ ]))->filter(function ($recipient) {
+        $recipients = collect(config('laravel-security-checker.recipients', []))->filter(function ($recipient) {
             return !is_null($recipient) && !empty($recipient);
         });
 

--- a/src/Console/SecuritySlackCommand.php
+++ b/src/Console/SecuritySlackCommand.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Jorijn\LaravelSecurityChecker\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Notification;
+use Jorijn\LaravelSecurityChecker\Notifications\SecuritySlackNotification;
+use SensioLabs\Security\SecurityChecker;
+
+class SecuritySlackCommand extends Command
+{
+    /**
+     * @var string
+     */
+    protected $name = 'security-check:slack';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Send any vulnerabilities for packages you have in your composer.lock file to a Slack channel.';
+
+    /**
+     * @var SecurityChecker
+     */
+    protected $checker;
+
+    /**
+     * SecurityCommand constructor.
+     *
+     * @param SecurityChecker $checker
+     */
+    public function __construct(SecurityChecker $checker)
+    {
+        parent::__construct();
+
+        $this->checker = $checker;
+    }
+
+    /**
+     * Execute the command
+     */
+    public function handle()
+    {
+        // require that the user specifies a slack channel in the .env file
+        if (!config('laravel-security-checker.slack_webhook_url')) {
+            throw new \Exception('No Slack Webhook has been specified.');
+        }
+
+        // get the path to composer.lock
+        $composerLock = base_path('composer.lock');
+
+        // and feed it into the SecurityChecker
+        $vulnerabilities = $this->checker->check($composerLock);
+
+        // cancel execution here if user does not want to be notified when there are 0 vulns.
+        $proceed = config('laravel-security-checker.email_even_without_vulnerabilities', false);
+        if (count($vulnerabilities) === 0 && $proceed !== true) {
+            return 0;
+        }
+
+        Notification::route('slack', config('laravel-security-checker.slack_webhook_url', null))
+            ->notify(new SecuritySlackNotification($vulnerabilities, realpath($composerLock)));
+    }
+}

--- a/src/Console/SecuritySlackCommand.php
+++ b/src/Console/SecuritySlackCommand.php
@@ -17,7 +17,7 @@ class SecuritySlackCommand extends Command
     /**
      * @var string
      */
-    protected $description = 'Send any vulnerabilities for packages you have in your composer.lock file to a Slack channel.';
+    protected $description = 'Send vulnerabilities to a Slack channel.';
 
     /**
      * @var SecurityChecker

--- a/src/Notifications/SecuritySlackNotification.php
+++ b/src/Notifications/SecuritySlackNotification.php
@@ -42,7 +42,7 @@ class SecuritySlackNotification extends Notification
      */
     public function via()
     {
-        return ['slack'];
+        return [ 'slack' ];
     }
 
     /**
@@ -55,9 +55,8 @@ class SecuritySlackNotification extends Notification
         return (new SlackMessage)
             ->from(config('app.url'))
             ->content("*Security Check Report:* `{$this->composerLockPath}`")
-            ->attachment(function ($attachment) {
-                $attachment->content($this->textFormatter())
-                    ->markdown(['text']);
+            ->attachment(function($attachment) {
+                $attachment->content($this->textFormatter())->markdown(['text']);
             });
     }
 
@@ -82,19 +81,19 @@ class SecuritySlackNotification extends Notification
 
         if (0 !== $count) {
             foreach ($this->vulnerabilities as $dependency => $issues) {
-                $dependencyFullName = $dependency . ' (' . $issues['version'] . ')';
+                $dependencyFullName = $dependency.' ('.$issues[ 'version' ].')';
                 $txt .= "\n";
-                $txt .= "*{$dependencyFullName}*" . "\n" . str_repeat('-', strlen($dependencyFullName)) . "\n";
+                $txt .= "*{$dependencyFullName}*"."\n".str_repeat('-', strlen($dependencyFullName))."\n";
 
-                foreach ($issues['advisories'] as $issue => $details) {
+                foreach ($issues[ 'advisories' ] as $issue => $details) {
                     $txt .= ' * ';
-                    if ($details['cve']) {
-                        $txt .= "{$details['cve']} ";
+                    if ($details[ 'cve' ]) {
+                        $txt .= "{$details[ 'cve' ]} ";
                     }
-                    $txt .= "{$details['title']} ";
+                    $txt .= "{$details[ 'title' ]} ";
 
-                    if ('' !== $details['link']) {
-                        $txt .= "{$details['link']}";
+                    if ('' !== $details[ 'link' ]) {
+                        $txt .= "{$details[ 'link' ]}";
                     }
 
                     $txt .= "\n";

--- a/src/Notifications/SecuritySlackNotification.php
+++ b/src/Notifications/SecuritySlackNotification.php
@@ -57,7 +57,7 @@ class SecuritySlackNotification extends Notification
             ->content("*Security Check Report:* `{$this->composerLockPath}`")
             ->attachment(function ($attachment) {
                 $attachment->content($this->textFormatter())
-                    ->markdown(['pretext']);
+                    ->markdown(['text']);
             });
     }
 

--- a/src/Notifications/SecuritySlackNotification.php
+++ b/src/Notifications/SecuritySlackNotification.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Jorijn\LaravelSecurityChecker\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Messages\SlackMessage;
+
+class SecuritySlackNotification extends Notification
+{
+    use SerializesModels, Queueable;
+
+    /**
+     *
+     * @var array
+     */
+    protected $vulnerabilities;
+
+    /**
+     *
+     * @var string
+     */
+    protected $composerLockPath;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct($vulnerabilities, $composerLockPath)
+    {
+        $this->vulnerabilities = $vulnerabilities;
+        $this->composerLockPath = $composerLockPath;
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['slack'];
+    }
+
+    /**
+     * Get the slack representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\SlackMessage
+     */
+    public function toSlack($notifiable)
+    {
+        $vulnerabilities = $this->vulnerabilities;
+
+        return (new SlackMessage)
+            ->from(config('app.url'))
+            ->content("*Security Check Report:* `{$this->composerLockPath}`")
+            ->attachment(function ($attachment) {
+                $attachment->content($this->textFormatter())
+                ->markdown(['pretext']);
+            });
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return $this->vulnerabilities;
+    }
+
+    protected function textFormatter()
+    {
+        $count = count($this->vulnerabilities);
+
+        $txt = sprintf("%d %s known vulnerabilities\n", $count, 1 === $count ? 'package has' : 'packages have');
+
+        if (0 !== $count) {
+            foreach ($this->vulnerabilities as $dependency => $issues) {
+                $dependencyFullName = $dependency . ' (' . $issues['version'] . ')';
+                $txt .= "\n";
+                $txt .= "*{$dependencyFullName}*" . "\n" . str_repeat('-', strlen($dependencyFullName)) . "\n";
+
+                foreach ($issues['advisories'] as $issue => $details) {
+                    $txt .= ' * ';
+                    if ($details['cve']) {
+                        $txt .= "{$details['cve']} ";
+                    }
+                    $txt .= "{$details['title']} ";
+
+                    if ('' !== $details['link']) {
+                        $txt .= "{$details['link']}";
+                    }
+
+                    $txt .= "\n";
+                }
+            }
+        }
+        return $txt;
+    }
+}

--- a/src/Notifications/SecuritySlackNotification.php
+++ b/src/Notifications/SecuritySlackNotification.php
@@ -26,7 +26,8 @@ class SecuritySlackNotification extends Notification
     /**
      * Create a new notification instance.
      *
-     * @return void
+     * @param $vulnerabilities
+     * @param $composerLockPath
      */
     public function __construct($vulnerabilities, $composerLockPath)
     {
@@ -37,10 +38,9 @@ class SecuritySlackNotification extends Notification
     /**
      * Get the notification's delivery channels.
      *
-     * @param  mixed  $notifiable
      * @return array
      */
-    public function via($notifiable)
+    public function via()
     {
         return ['slack'];
     }
@@ -48,33 +48,32 @@ class SecuritySlackNotification extends Notification
     /**
      * Get the slack representation of the notification.
      *
-     * @param  mixed  $notifiable
-     * @return \Illuminate\Notifications\Messages\SlackMessage
+     * @return SlackMessage
      */
-    public function toSlack($notifiable)
+    public function toSlack()
     {
-        $vulnerabilities = $this->vulnerabilities;
-
         return (new SlackMessage)
             ->from(config('app.url'))
             ->content("*Security Check Report:* `{$this->composerLockPath}`")
             ->attachment(function ($attachment) {
                 $attachment->content($this->textFormatter())
-                ->markdown(['pretext']);
+                    ->markdown(['pretext']);
             });
     }
 
     /**
      * Get the array representation of the notification.
      *
-     * @param  mixed  $notifiable
      * @return array
      */
-    public function toArray($notifiable)
+    public function toArray()
     {
         return $this->vulnerabilities;
     }
 
+    /**
+     * @return string
+     */
     protected function textFormatter()
     {
         $count = count($this->vulnerabilities);

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -22,7 +22,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
      */
     public function register()
     {
-        $configPath = __DIR__ . '/../config/laravel-security-checker.php';
+        $configPath = __DIR__.'/../config/laravel-security-checker.php';
         $this->mergeConfigFrom($configPath, 'laravel-security-checker');
     }
 
@@ -34,19 +34,19 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     public function boot()
     {
         // configuration
-        $configPath = __DIR__ . '/../config/laravel-security-checker.php';
-        $this->publishes([$configPath => $this->getConfigPath()], 'config');
+        $configPath = __DIR__.'/../config/laravel-security-checker.php';
+        $this->publishes([ $configPath => $this->getConfigPath() ], 'config');
 
         // views
-        $this->loadViewsFrom(__DIR__ . '/../resources/views', 'laravel-security-checker');
+        $this->loadViewsFrom(__DIR__.'/../resources/views', 'laravel-security-checker');
         $this->publishes([
-            __DIR__ . '/../resources/views' => resource_path('views/vendor/laravel-security-checker'),
+            __DIR__.'/../resources/views' => resource_path('views/vendor/laravel-security-checker'),
         ], 'views');
 
         // translations
-        $this->loadTranslationsFrom(__DIR__ . '/../resources/lang', 'laravel-security-checker');
+        $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'laravel-security-checker');
         $this->publishes([
-            __DIR__ . '/../resources/lang' => resource_path('lang/vendor/laravel-security-checker'),
+            __DIR__.'/../resources/lang' => resource_path('lang/vendor/laravel-security-checker'),
         ], 'translations');
 
         if ($this->app->runningInConsole()) {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -4,6 +4,7 @@ namespace Jorijn\LaravelSecurityChecker;
 
 use Jorijn\LaravelSecurityChecker\Console\SecurityCommand;
 use Jorijn\LaravelSecurityChecker\Console\SecurityMailCommand;
+use Jorijn\LaravelSecurityChecker\Console\SecuritySlackCommand;
 
 class ServiceProvider extends \Illuminate\Support\ServiceProvider
 {
@@ -21,7 +22,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
      */
     public function register()
     {
-        $configPath = __DIR__.'/../config/laravel-security-checker.php';
+        $configPath = __DIR__ . '/../config/laravel-security-checker.php';
         $this->mergeConfigFrom($configPath, 'laravel-security-checker');
     }
 
@@ -33,25 +34,26 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     public function boot()
     {
         // configuration
-        $configPath = __DIR__.'/../config/laravel-security-checker.php';
-        $this->publishes([ $configPath => $this->getConfigPath() ], 'config');
+        $configPath = __DIR__ . '/../config/laravel-security-checker.php';
+        $this->publishes([$configPath => $this->getConfigPath()], 'config');
 
         // views
-        $this->loadViewsFrom(__DIR__.'/../resources/views', 'laravel-security-checker');
+        $this->loadViewsFrom(__DIR__ . '/../resources/views', 'laravel-security-checker');
         $this->publishes([
-            __DIR__.'/../resources/views' => resource_path('views/vendor/laravel-security-checker'),
+            __DIR__ . '/../resources/views' => resource_path('views/vendor/laravel-security-checker'),
         ], 'views');
 
         // translations
-        $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'laravel-security-checker');
+        $this->loadTranslationsFrom(__DIR__ . '/../resources/lang', 'laravel-security-checker');
         $this->publishes([
-            __DIR__.'/../resources/lang' => resource_path('lang/vendor/laravel-security-checker'),
+            __DIR__ . '/../resources/lang' => resource_path('lang/vendor/laravel-security-checker'),
         ], 'translations');
 
         if ($this->app->runningInConsole()) {
             $this->commands([
                 SecurityCommand::class,
                 SecurityMailCommand::class,
+                SecuritySlackCommand::class,
             ]);
         }
     }

--- a/tests/SecuritySlackCommandTest.php
+++ b/tests/SecuritySlackCommandTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Jorijn\LaravelSecurityChecker\Tests;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Notification;
+use SensioLabs\Security\SecurityChecker;
+use Jorijn\LaravelSecurityChecker\Notifications\SecuritySlackNotification;
+use Illuminate\Notifications\AnonymousNotifiable;
+use Mockery\CountValidator\Exception;
+
+class SecuritySlackCommandTest extends TestCase
+{
+    /**
+     * @var array
+     */
+    protected $exampleCheckOutput;
+
+    /**
+     * Set Up
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        // declare fake vulnerability
+        $this->exampleCheckOutput = $this->getFakeVulnerabilityReport();
+
+        // mock the security checker
+        $securityCheckerMock = \Mockery::mock(SecurityChecker::class);
+        $securityCheckerMock->shouldReceive('check')->andReturn($this->exampleCheckOutput);
+
+        // bind Mockery instance to the app container
+        $this->app->instance(SecurityChecker::class, $securityCheckerMock);
+
+        // declare testing mode on the notification
+        Notification::fake();
+    }
+
+    /**
+     * Tests if the notification get's sent
+     */
+    public function testHandleMethod()
+    {
+        // set the recipient for testing
+        Config::set(
+            'laravel-security-checker.slack_webhook_url',
+            'https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX'
+        );
+
+        // execute the command
+        $res = $this->artisan('security-check:slack');
+
+        // assert that the exit-code is 0
+        $this->assertEquals($res, 0);
+
+        // https://github.com/laravel/framework/pull/21379
+        Notification::assertSentTo( 
+            new AnonymousNotifiable, 
+            SecuritySlackNotification::class,
+            function ($notification, $channels, $notifiable) {
+                return $notifiable->routes['slack'] == config('laravel-security-checker.slack_webhook_url');
+            }
+        );
+    }
+
+    /**
+     * Tests that no notification is sent if a Slack Webhook has not been configured.
+     */
+    public function testHandleMethodWithoutSlackWebHook()
+    {
+        // set the recipient for testing
+        Config::set('laravel-security-checker.slack_webhook_url', null);
+
+        // Class should throw exception if no webhook is configured
+        $this->expectException(\Exception::class);
+
+        // execute the command
+        $res = $this->artisan('security-check:slack');
+
+        // assert that the exit-code is 1
+        $this->assertEquals($res, 1);
+
+        Notification::assertNotSentTo( 
+            new AnonymousNotifiable, 
+            SecuritySlackNotification::class
+        );
+    }
+
+    /**
+     * Test that no notification get's sent if there are no vulnerabilities
+     */
+    public function testHandleMethodWithoutVulnerabilities()
+    {
+        // set the recipient for testing
+        Config::set(
+            'laravel-security-checker.slack_webhook_url',
+            'https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX'
+        );
+
+        // we have to re-bind the mockery instance for this since our parent one does hold
+        // fake vulnerabilities.
+        $securityCheckerMock = \Mockery::mock(SecurityChecker::class);
+        $securityCheckerMock->shouldReceive('check')->andReturn([]);
+
+        // bind Mockery instance to the app container
+        $this->app->instance(SecurityChecker::class, $securityCheckerMock);
+
+        // execute the command
+        $res = $this->artisan('security-check:slack');
+
+        // check that the notification wasn't sent
+        Notification::assertNotSentTo( 
+            new AnonymousNotifiable, 
+            SecuritySlackNotification::class
+        );
+
+        // assert that the exit-code is 0
+        $this->assertEquals($res, 0);
+    }
+}

--- a/tests/SecuritySlackTest.php
+++ b/tests/SecuritySlackTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Jorijn\LaravelSecurityChecker\Tests;
+
+use Illuminate\Support\Facades\Config;
+use Jorijn\LaravelSecurityChecker\Notifications\SecuritySlackNotification;
+
+class SecuritySlackTest extends TestCase
+{
+    /**
+     * This method tests if the SecuritySlackNotification class gets rendered correctly.
+     */
+    public function testSlackNotification()
+    {
+        $vulnerabilities = $this->getFakeVulnerabilityReport();
+        $composerLockPath = '/path/to/composer.lock';
+        $notification = new SecuritySlackNotification($vulnerabilities, $composerLockPath);
+
+        $this->assertInstanceOf(SecuritySlackNotification::class, $notification);
+
+        $generatedNotification = $notification->toSlack();
+
+        $this->assertEquals($notification->via()[0], 'slack');
+        $this->assertEquals($notification->toArray(), $vulnerabilities);
+        $this->assertEquals($generatedNotification->username, config('app.url'));
+        $this->assertEquals($generatedNotification->content, "*Security Check Report:* `{$composerLockPath}`");
+        $this->assertEquals(count($generatedNotification->attachments), count($vulnerabilities));
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,7 +12,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
      */
     protected function getPackageProviders($app)
     {
-        return [ ServiceProvider::class ];
+        return [ServiceProvider::class];
     }
 
     /**
@@ -23,13 +23,13 @@ class TestCase extends \Orchestra\Testbench\TestCase
     public function getFakeVulnerabilityReport()
     {
         return [
-            "bugsnag/bugsnag-laravel" => [
-                "version" => "v2.0.1",
-                "advisories" => [
-                    "bugsnag/bugsnag-laravel/CVE-2016-5385.yaml" => [
-                        "title" => "HTTP Proxy header vulnerability",
-                        "link" => "https://github.com/bugsnag/bugsnag-laravel/releases/tag/v2.0.2",
-                        "cve" => "CVE-2016-5385"
+            'bugsnag/bugsnag-laravel' => [
+                'version' => 'v2.0.1',
+                'advisories' => [
+                    'bugsnag/bugsnag-laravel/CVE-2016-5385.yaml' => [
+                        'title' => 'HTTP Proxy header vulnerability',
+                        'link' => 'https://github.com/bugsnag/bugsnag-laravel/releases/tag/v2.0.2',
+                        'cve' => 'CVE-2016-5385'
                     ]
                 ]
             ]


### PR DESCRIPTION
- Renamed the fire() methods to handle()
- Upgrading to phpunit/phpunit to 6 allows tests to pass.