### PR TITLE
Upgrade sensiolabs/security-checker to version 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     }
   ],
   "require": {
-    "sensiolabs/security-checker": "^5.0.0",
-    "php": ">=7.0",
+    "sensiolabs/security-checker": "^6.0.0",
+    "php": ">=7.1.3",
     "guzzlehttp/guzzle": "^6.3",
     "illuminate/support": "5.5.x|5.6.x|5.7.x|5.8.x|6.x",
     "illuminate/console": "5.5.x|5.6.x|5.7.x|5.8.x|6.x",


### PR DESCRIPTION
Upgrades sensiolabs/security-checker to version 6.
sensiolabs/security-checker requires PHP 7.1.3 or greater so needed to change the requirements from PHP >7.0 to >7.1.3