### PR TITLE
Laravel 11.x Compatibility

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,5 +53,14 @@ jobs:
           composer require "illuminate/contracts=${{ matrix.laravel }}" --no-update
           composer update --prefer-dist --no-interaction --no-progress
 
-      - name: Execute tests
+      - name: Grab PHPUnit version
+        id: phpunit_version
+        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
+
+      - name: Execute tests (PHPUnit 10)
+        if: ${{ startsWith(steps.phpunit_version.outputs.VERSION, '10.') }}
+        run: vendor/bin/phpunit --configuration=phpunit10.xml.dist
+
+      - name: Execute tests (PHPUnit < 10)
+        if: ${{ !startsWith(steps.phpunit_version.outputs.VERSION, '10.') }}
         run: vendor/bin/phpunit --configuration=phpunit.xml.dist

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -54,4 +54,4 @@ jobs:
           composer update --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
-        run: vendor/bin/phpunit --verbose --configuration=phpunit.xml.dist
+        run: vendor/bin/phpunit --configuration=phpunit.xml.dist

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,26 +14,36 @@ jobs:
         php: [7.4, 8.0, 8.1, 8.2, 8.3]
         laravel: ['6.*', '7.*', '8.*', '9.*', '10.*', '11.*']
         exclude:
+          - php: 7.4
+            laravel: 11.*
+          - php: 8.0
+            laravel: 11.*
+          - php: 8.1
+            laravel: 11.*
+          - php: 7.4
+            laravel: 10.*
           - php: 8.0
             laravel: 10.*
           - php: 7.4
-            laravel: 10.*
-          - php: 7.4
             laravel: 9.*
-          - php: 8.1
-            laravel: 6.*
+          - php: 8.3
+            laravel: 9.*
+          - php: 8.2
+            laravel: 8.*
+          - php: 8.3
+            laravel: 8.*
           - php: 8.1
             laravel: 7.*
           - php: 8.2
+            laravel: 7.*
+          - php: 8.3
+            laravel: 7.*
+          - php: 8.1
             laravel: 6.*
           - php: 8.2
-            laravel: 7.*
-          - laravel: 11.*
-            php: 7.4
-          - laravel: 11.*
-            php: 8.0
-          - laravel: 11.*
-            php: 8.1
+            laravel: 6.*
+          - php: 8.3
+            laravel: 6.*
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.4, 8.0, 8.1, 8.2]
+        php: [7.4, 8.0, 8.1, 8.2, 8.3]
         laravel: ['6.*', '7.*', '8.*', '9.*', '10.*', '11.*']
         exclude:
           - php: 8.0

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,7 +46,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, json
-          coverage: none
+          coverage: pcov
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,13 +7,13 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+
     strategy:
       fail-fast: false
       matrix:
         php: [7.4, 8.0, 8.1, 8.2]
-        laravel: [6.*, 7.*, 8.*, 9.*, 10.*]
+        laravel: ['6.*', '7.*', '8.*', '9.*', '10.*', '11.*']
         exclude:
-          # excludes unsupported combinations
           - php: 8.0
             laravel: 10.*
           - php: 7.4
@@ -28,6 +28,12 @@ jobs:
             laravel: 6.*
           - php: 8.2
             laravel: 7.*
+          - laravel: 11.*
+            php: 7.4
+          - laravel: 11.*
+            php: 8.0
+          - laravel: 11.*
+            php: 8.1
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 
@@ -46,5 +52,6 @@ jobs:
         run: |
           composer require "illuminate/contracts=${{ matrix.laravel }}" --no-update
           composer update --prefer-dist --no-interaction --no-progress
+
       - name: Execute tests
         run: vendor/bin/phpunit --verbose --configuration=phpunit.xml.dist

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 .idea
 build
 .phpunit.result.cache
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -17,20 +17,20 @@
     "require": {
         "php": ">=7.4|^8.0",
         "guzzlehttp/guzzle": "^7.0",
-        "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0",
-        "illuminate/console": "^6.0|^7.0|^8.0|^9.0|^10.0",
-        "illuminate/bus": "^6.0|^7.0|^8.0|^9.0|^10.0",
-        "illuminate/mail": "^6.0|^7.0|^8.0|^9.0|^10.0",
-        "illuminate/queue": "^6.0|^7.0|^8.0|^9.0|^10.0",
-        "illuminate/notifications": "^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+        "illuminate/console": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+        "illuminate/bus": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+        "illuminate/mail": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+        "illuminate/queue": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+        "illuminate/notifications": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
         "ext-json": "*",
-        "enlightn/security-checker": "^1.3"
+        "enlightn/security-checker": "^1.3|^2.0"
     },
     "require-dev": {
-        "laravel/slack-notification-channel": "^1.0|^2.0",
-        "phpunit/phpunit": "^6.0|^7.0|^8.0|^9.0",
+        "laravel/slack-notification-channel": "^1.0|^2.0|^3.2",
+        "phpunit/phpunit": "^6.0|^7.0|^8.0|^9.0|^10.5",
         "squizlabs/php_codesniffer": "~2.3|^3.6",
-        "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0|^8.0",
+        "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0|^8.0|^9.0",
         "mockery/mockery": "^1.2"
     },
     "suggest": {

--- a/phpunit10.xml.dist
+++ b/phpunit10.xml.dist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name=":vendor Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <coverage>
+        <report>
+            <html outputDirectory="build/coverage"/>
+            <text outputFile="build/coverage.txt"/>
+            <clover outputFile="build/logs/clover.xml"/>
+        </report>
+    </coverage>
+    <logging>
+        <junit outputFile="build/report.junit.xml"/>
+    </logging>
+    <source>
+        <include>
+            <directory>./src</directory>
+        </include>
+    </source>
+</phpunit>


### PR DESCRIPTION
This PR is based on the work of @laravel-shift via #46.

Additional changes to fix Laravel 11.x and PHPUnit 10.x support:
- build: Remove obsolete verbose flag for PHPUnit
- build: Use PCOV for code coverage
- test: Provide dedicated PHPUnit 10 support
- build: Added PHP 8.3 to test matrix
- build: Updated test matrix excludes according to [Laravel support policies](https://laravel.com/docs/11.x/releases)

Also update actions/checkout from v2 to v4 (related to https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/).
