### PR TITLE
feat: PHP 8.4 and Laravel 12 support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "illuminate/contracts=${{ matrix.laravel }}" --no-update
+          composer require "illuminate/contracts=${{ matrix.laravel }}" --prefer-stable --no-update
           composer update --prefer-dist --no-interaction --no-progress
 
       - name: Grab PHPUnit version

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [7.4, 8.0, 8.1, 8.2, 8.3]
-        laravel: ['6.*', '7.*', '8.*', '9.*', '10.*', '11.*']
+        laravel: ['6.*', '7.*', '8.*', '9.*', '10.*', '11.*', '12.*']
         exclude:
           - php: 7.4
             laravel: 11.*
@@ -44,6 +44,12 @@ jobs:
             laravel: 6.*
           - php: 8.3
             laravel: 6.*
+          - laravel: 12.*
+            php: 7.4
+          - laravel: 12.*
+            php: 8.0
+          - laravel: 12.*
+            php: 8.1
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 
@@ -68,9 +74,9 @@ jobs:
         run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
 
       - name: Execute tests (PHPUnit 10)
-        if: ${{ startsWith(steps.phpunit_version.outputs.VERSION, '10.') }}
+        if: "${{ startsWith(steps.phpunit_version.outputs.VERSION, '10.') }}"
         run: vendor/bin/phpunit --configuration=phpunit10.xml.dist
 
       - name: Execute tests (PHPUnit < 10)
-        if: ${{ !startsWith(steps.phpunit_version.outputs.VERSION, '10.') }}
+        if: "${{ !startsWith(steps.phpunit_version.outputs.VERSION, '10.') }}"
         run: vendor/bin/phpunit --configuration=phpunit.xml.dist

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -69,14 +69,14 @@ jobs:
           composer require "illuminate/contracts=${{ matrix.laravel }}" --prefer-stable --no-update
           composer update --prefer-dist --no-interaction --no-progress
 
-      - name: Grab PHPUnit version
+      - name: Grab PHPUnit major version
         id: phpunit_version
-        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
+        run: echo "MAJOR_VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+' | cut -d '.' -f 1)" >> $GITHUB_OUTPUT
 
-      - name: Execute tests (PHPUnit 10)
-        if: "${{ startsWith(steps.phpunit_version.outputs.VERSION, '10.') }}"
+      - name: Execute tests (PHPUnit >= 10)
+        if: "${{ fromJSON(steps.phpunit_version.outputs.MAJOR_VERSION) >= 10 }}"
         run: vendor/bin/phpunit --configuration=phpunit10.xml.dist
 
       - name: Execute tests (PHPUnit < 10)
-        if: "${{ !startsWith(steps.phpunit_version.outputs.VERSION, '10.') }}"
+        if: "${{ fromJSON(steps.phpunit_version.outputs.MAJOR_VERSION) < 10 }}"
         run: vendor/bin/phpunit --configuration=phpunit.xml.dist

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,10 +11,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.4, 8.0, 8.1, 8.2, 8.3]
+        php: [7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
         laravel: ['6.*', '7.*', '8.*', '9.*', '10.*', '11.*', '12.*']
         exclude:
           - php: 7.4
+            laravel: 12.*
+          - php: 8.0
+            laravel: 12.*
+          - php: 8.1
+            laravel: 12.*
+          - php: 7.4
             laravel: 11.*
           - php: 8.0
             laravel: 11.*
@@ -24,13 +30,19 @@ jobs:
             laravel: 10.*
           - php: 8.0
             laravel: 10.*
+          - php: 8.4
+            laravel: 10.*
           - php: 7.4
             laravel: 9.*
           - php: 8.3
             laravel: 9.*
+          - php: 8.4
+            laravel: 9.*
           - php: 8.2
             laravel: 8.*
           - php: 8.3
+            laravel: 8.*
+          - php: 8.4
             laravel: 8.*
           - php: 8.1
             laravel: 7.*
@@ -38,18 +50,16 @@ jobs:
             laravel: 7.*
           - php: 8.3
             laravel: 7.*
+          - php: 8.4
+            laravel: 7.*
           - php: 8.1
             laravel: 6.*
           - php: 8.2
             laravel: 6.*
           - php: 8.3
             laravel: 6.*
-          - laravel: 12.*
-            php: 7.4
-          - laravel: 12.*
-            php: 8.0
-          - laravel: 12.*
-            php: 8.1
+          - php: 8.4
+            laravel: 6.*
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -17,20 +17,20 @@
     "require": {
         "php": ">=7.4|^8.0",
         "guzzlehttp/guzzle": "^7.0",
-        "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
-        "illuminate/console": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
-        "illuminate/bus": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
-        "illuminate/mail": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
-        "illuminate/queue": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
-        "illuminate/notifications": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/console": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/bus": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/mail": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/queue": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/notifications": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
         "ext-json": "*",
         "enlightn/security-checker": "^1.3|^2.0"
     },
     "require-dev": {
         "laravel/slack-notification-channel": "^1.0|^2.0|^3.2",
-        "phpunit/phpunit": "^6.0|^7.0|^8.0|^9.0|^10.5",
+        "phpunit/phpunit": "^6.0|^7.0|^8.0|^9.0|^10.5|^11.5.3",
         "squizlabs/php_codesniffer": "~2.3|^3.6",
-        "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0|^8.0|^9.0",
+        "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0|^8.0|^9.0|^10.0",
         "mockery/mockery": "^1.2"
     },
     "suggest": {


### PR DESCRIPTION
Based on https://github.com/jorijn/laravel-security-checker/pull/60 with additional PHP 8.4 test support and a fix regarding the conditional PHPUnit execution.

@jorijn LGTM 🙌 